### PR TITLE
Metadata file fixup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2014 Open Source Robotics Foundation, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -20,6 +20,8 @@ import sys
 
 from multiprocessing import cpu_count
 
+from catkin_tools.common import wide_log
+
 
 def add_context_args(parser):
     """Add common workspace and profile args to an argparse parser.

--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -14,10 +14,8 @@
 
 from __future__ import print_function
 
-import datetime
 import os
 import re
-import stat
 import sys
 
 from multiprocessing import cpu_count

--- a/catkin_tools/argument_parsing.py
+++ b/catkin_tools/argument_parsing.py
@@ -74,7 +74,8 @@ def add_cmake_and_make_and_catkin_make_args(parser):
         help='Pass no additional arguments to make (does not affect --catkin-make-args).')
 
     add = parser.add_mutually_exclusive_group().add_argument
-    add('--catkin-make-args', metavar='ARG', dest='catkin_make_args', nargs='+', required=False, type=str, default=None,
+    add('--catkin-make-args', metavar='ARG', dest='catkin_make_args',
+        nargs='+', required=False, type=str, default=None,
         help='Arbitrary arguments which are passes to make but only for catkin packages.'
              'It must be passed after other arguments since it collects all following options.')
     add('--no-catkin-make-args', dest='catkin_make_args', action='store_const', const=[], default=None,

--- a/catkin_tools/common.py
+++ b/catkin_tools/common.py
@@ -17,15 +17,9 @@ from __future__ import print_function
 import datetime
 import os
 import re
-import stat
-import sys
-
-from multiprocessing import cpu_count
 
 from catkin_pkg.packages import find_packages
-from catkin_pkg.package import InvalidPackage
 
-from .runner import run_command
 from .terminal_color import ColorMapper
 
 color_mapper = ColorMapper()

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -1,42 +1,7 @@
 
 import os
-import stat
-import sys
-import time
 import re
-from copy import copy
 
-from multiprocessing import cpu_count
-from threading import Lock
-try:
-    # Python3
-    from queue import Queue
-    from queue import Empty
-except ImportError:
-    # Python2
-    from Queue import Queue
-    from Queue import Empty
-
-try:
-    from catkin_pkg.packages import find_packages
-    from catkin_pkg.topological_order import topological_order_packages
-except ImportError as e:
-    sys.exit(
-        'ImportError: "from catkin_pkg.topological_order import '
-        'topological_order" failed: %s\nMake sure that you have installed '
-        '"catkin_pkg", and that it is up to date and on the PYTHONPATH.' % e
-    )
-
-
-from .common import disable_wide_log
-from .common import FakeLock
-from .common import format_time_delta
-from .common import format_time_delta_short
-from .common import get_cached_recursive_build_depends_in_workspace
-from .common import get_recursive_run_depends_in_workspace
-from .common import is_tty
-from .common import log
-from .common import wide_log
 from .common import run_command
 
 

--- a/catkin_tools/resultspace.py
+++ b/catkin_tools/resultspace.py
@@ -69,7 +69,6 @@ def get_resultspace_environment(result_space_path, quiet=False):
     env_regex = re.compile('(.+?)=(.*)$', re.M)
     env_dict = {}
 
-    captured_lines = []
     for line in run_command(command, cwd=os.getcwd()):
         if isinstance(line, str):
             matches = env_regex.findall(line)

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -18,7 +18,6 @@ import os
 import stat
 import sys
 import time
-import re
 import yaml
 
 from multiprocessing import cpu_count
@@ -43,8 +42,6 @@ except ImportError as e:
     )
 
 from catkin_tools.notifications import notify
-
-from catkin_tools.runner import run_command
 
 from catkin_tools.common import disable_wide_log
 from catkin_tools.common import FakeLock

--- a/catkin_tools/verbs/catkin_build/build.py
+++ b/catkin_tools/verbs/catkin_build/build.py
@@ -575,7 +575,7 @@ def build_isolated_workspace(
                 # Update the status bar on the screen
                 executing_jobs = []
                 for name, value in running_jobs.items():
-                    number, job, start_time = value['package_number'], value['job'], value['start_time']
+                    number, start_time = value['package_number'], value['start_time']
                     if number is None or start_time is None:
                         continue
                     executing_jobs.append({

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 import sys
 import time
 
+from catkin_pkg.package import InvalidPackage
+
 from catkin_tools.argument_parsing import add_context_args
 from catkin_tools.argument_parsing import add_cmake_and_make_and_catkin_make_args
 
@@ -143,7 +145,7 @@ def main(opts):
         # Determine the enclosing package
         try:
             this_package = find_enclosing_package()
-        except catkin_pkg.package.InvalidPackage as ex:
+        except InvalidPackage:
             pass
 
         # Handle context-based package building

--- a/catkin_tools/verbs/catkin_build/cli.py
+++ b/catkin_tools/verbs/catkin_build/cli.py
@@ -14,8 +14,6 @@
 
 from __future__ import print_function
 
-import os
-import re
 import sys
 import time
 

--- a/catkin_tools/verbs/catkin_build/common.py
+++ b/catkin_tools/verbs/catkin_build/common.py
@@ -14,17 +14,9 @@
 
 from __future__ import print_function
 
-import datetime
 import os
-import re
 import stat
 import sys
-
-from multiprocessing import cpu_count
-
-from catkin_tools.runner import run_command
-
-from .color import clr
 
 env_file_template = """\
 #!/usr/bin/env sh

--- a/catkin_tools/verbs/catkin_clean/cli.py
+++ b/catkin_tools/verbs/catkin_clean/cli.py
@@ -23,9 +23,6 @@ from catkin_tools.argument_parsing import add_context_args
 
 from catkin_tools.context import Context
 
-from catkin_tools.metadata import find_enclosing_workspace
-from catkin_tools.metadata import get_active_profile
-from catkin_tools.metadata import get_metadata
 from catkin_tools.metadata import update_metadata
 
 from catkin_tools.terminal_color import ColorMapper

--- a/catkin_tools/verbs/catkin_config/cli.py
+++ b/catkin_tools/verbs/catkin_config/cli.py
@@ -16,14 +16,10 @@ from __future__ import print_function
 
 import os
 
-from catkin_pkg.packages import find_packages
-
 from catkin_tools.argument_parsing import add_cmake_and_make_and_catkin_make_args
 from catkin_tools.argument_parsing import add_context_args
 
 from catkin_tools.context import Context
-
-from catkin_tools.terminal_color import fmt
 
 
 def prepare_arguments(parser):

--- a/catkin_tools/verbs/catkin_create/cli.py
+++ b/catkin_tools/verbs/catkin_create/cli.py
@@ -15,22 +15,8 @@
 from __future__ import print_function
 
 import os
-import shutil
 
-from catkin_pkg.package import Export
-from catkin_pkg.packages import find_packages
 from catkin_pkg.package_templates import create_package_files, PackageTemplate
-
-from catkin_tools.argument_parsing import add_context_args
-
-from catkin_tools.context import Context
-
-from catkin_tools.runner import run_command
-
-from catkin_tools.metadata import find_enclosing_workspace
-from catkin_tools.metadata import get_active_profile
-from catkin_tools.metadata import get_metadata
-from catkin_tools.metadata import update_metadata
 
 # Exempt build directories
 # See https://github.com/catkin/catkin_tools/issues/82

--- a/catkin_tools/verbs/catkin_init/cli.py
+++ b/catkin_tools/verbs/catkin_init/cli.py
@@ -16,13 +16,10 @@ from __future__ import print_function
 
 import os
 
-from catkin_pkg.packages import find_packages
-
 from catkin_tools.argument_parsing import add_workspace_arg
 
 from catkin_tools.context import Context
 
-from catkin_tools.metadata import find_enclosing_workspace
 from catkin_tools.metadata import init_metadata_root
 
 

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -14,10 +14,6 @@
 
 from __future__ import print_function
 
-import os
-
-from catkin_pkg.packages import find_packages
-
 from catkin_tools.context import Context
 
 from catkin_tools.metadata import get_active_profile

--- a/catkin_tools/verbs/catkin_profile/cli.py
+++ b/catkin_tools/verbs/catkin_profile/cli.py
@@ -41,6 +41,9 @@ def prepare_arguments(parser):
     add('--workspace', '-w', default=None,
         help='The path to the catkin workspace. Default: current working directory')
 
+    add = parser_list.add_argument
+    # Nothing to do here yet
+
     add = parser_set.add_argument
     add('name', type=str,
         help='The profile to activate.')

--- a/docs/advanced/verb_customization.rst
+++ b/docs/advanced/verb_customization.rst
@@ -45,7 +45,7 @@ value of the ``CMAKE_PREFIX_PATH`` environment variable, and instead *extends*
 one or another ROS install spaces could be defined as follows:
 
 .. code-block:: yaml
-  
+
   # ~/.config/catkin/verb_aliases/10-ros-distro-aliases.yaml
   extend-sys: config --profile sys --extend /opt/ros/hydro -x _sys
   extend-overlay: config --profile overlay --extend ~/ros/hydro/install -x _overlay
@@ -73,7 +73,7 @@ Alias Precedence and Overriding Aliases
 Verb alias files in the ``verb_aliases`` directory are processed in
 alphabetical order, so files which start with larger numbers will override
 files with smaller numbers.      In this way you can override the built-in
-aliases using a file which starts with a number higher than ``00-``. 
+aliases using a file which starts with a number higher than ``00-``.
 
 For example, the ``bt: build --this`` alias exists in the default alias file,
 ``00-default-aliases.yaml``, but you can create a file to override it with an

--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -2,8 +2,8 @@ Cheat Sheet
 ===========
 
 This is a non-exhaustive list of some common and useful invocations of the ``catkin`` command.
-All of the commands which do not explicitly specify a workspace path (with ``--workspace``) 
-are assumed to be run from within a directory contained by the target workspace. For thorough 
+All of the commands which do not explicitly specify a workspace path (with ``--workspace``)
+are assumed to be run from within a directory contained by the target workspace. For thorough
 documentation, please see the chapters on each verb.
 
 Initializing Workspaces
@@ -57,19 +57,19 @@ Build a specific package and its dependencies:
 
 ... or ignore its dependencies:
   - ``catkin build my_package --no-deps``
-  
+
 Build the package containing the current working directory:
   - ``catkin build --this``
 
 ... but don't rebuild its dependencies:
   - ``catkin build --this --no-deps``
-  
+
 Build packages with aditional CMake args:
   - ``catkin build --cmake-args -DCMAKE_BUILD_TYPE=Debug``
 
 ... and save them to be used for the next build:
   - ``catkin build --save-config --cmake-args -DCMAKE_BUILD_TYPE=Debug``
-  
+
 Cleaning Build Products
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -78,7 +78,7 @@ Blow away the build, devel, and install spaces (if they exist):
 
 ... or just the **build space**:
   - ``catkin clean --build``
-  
+
 ... or just delete the `CMakeCache.txt` files for each package:
   - ``catkin clean --cmake-cache``
 
@@ -108,12 +108,12 @@ Manipulating Workspace Chaining
 
 Change from implicit to explicit chaining:
   .. code-block:: bash
-    
+
     catkin clean -a
     catkin config --extend /opt/ros/hydro
 
 Change from explicit to implicit chaining:
   .. code-block:: bash
-    
+
     catkin clean -a
     catkin config --no-extend

--- a/docs/config_summary.rst
+++ b/docs/config_summary.rst
@@ -2,7 +2,7 @@ Configuration Summary
 =====================
 
 Contents of the Config Summary
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Most ``catkin`` comands which modify the a workspace's configuration will
 display the standard configuration summary, as shown below:

--- a/docs/config_summary.rst
+++ b/docs/config_summary.rst
@@ -8,7 +8,7 @@ Most ``catkin`` comands which modify the a workspace's configuration will
 display the standard configuration summary, as shown below:
 
 .. code-block:: bash
-    
+
     $ cd /tmp/path/to/my_catkin_ws
     $ catkin config
     --------------------------------------------------------------
@@ -47,22 +47,22 @@ Overview Section
   - *No Chaining*
 
     .. code-block:: bash
-        
+
           Extending:                   None
 
   - *Implicit Chaining* -- Derived from the ``CMAKE_PREFIX_PATH`` environment or cache variable.
 
     .. code-block:: bash
-        
+
           Extending:             [env] /opt/ros/hydro
     .. code-block:: bash
-        
+
           Extending:          [cached] /opt/ros/hydro
 
   - *Explicit Chaining* -- Specified by ``catkin config --extend``
 
     .. code-block:: bash
-        
+
           Extending:        [explicit] /opt/ros/hydro
 
 - **[* Space]** -- Lists the paths to each of the catkin "spaces" and whether or not they exist
@@ -85,7 +85,7 @@ Warnings Section
 ----------------
 
 If something is wrong with your configuration such as a missing source space,
-an additional secion will appear at the bottom of the summary with details on 
+an additional secion will appear at the bottom of the summary with details on
 what is wrong and how you can fix it.
 
 Workspace Chaining Mode
@@ -110,7 +110,7 @@ neither explicitly specified a workspace to extend, and the
 ``CMAKE_PREFIX_PATH`` environment variable is empty:
 
 .. code-block:: bash
-    
+
       Extending:                   None
 
 Implicit Chaining via ``CMAKE_PREFIX_PATH`` Environment or Cache Variable
@@ -127,19 +127,19 @@ calling something similar to ``source /opt/ros/hydro/setup.bash`` will
 normally see an ``Extending`` value such as:
 
 .. code-block:: bash
-    
+
       Extending:             [env] /opt/ros/hydro
 
 If you don't want to extend the given workspace, unsetting the
 ``CMAKE_PREFIX_PATH`` environment variable will change it back to none. You can
-also alternatively 
+also alternatively
 
 Once you have built your workspace once, this ``CMAKE_PREFIX_PATH`` will be
 cached by the underlying CMake buildsystem. As such, the ``Extending`` status
 will subsequently describe this as the "cached" extension path:
 
 .. code-block:: bash
-    
+
       Extending:          [cached] /opt/ros/hydro
 
 Once the extension mode is cached like this, you must use ``catkin clean`` to
@@ -155,6 +155,6 @@ which the other workspace extends, recursively.  This can be set with the
 ``CMAKE_PREFIX_PATH`` and persist between builds.
 
 .. code-block:: bash
-    
+
       Extending:        [explicit] /tmp/path/to/other_ws
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,8 +19,11 @@ Catkin Command Line Tools
    verbs/catkin_list
    verbs/catkin_profile
    Advanced: Verb Aliasing <advanced/verb_customization>
-   Advanced: Workspace Chaining <advanced/workspace_chaining>
+   Advanced: Profiles <advanced/profiles>
    Advanced: Contributing Verbs <development/extending_the_catkin_command>
+
+.. This document doesn't seem to exist.
+.. Advanced: Workspace Chaining <advanced/workspace_chaining>
 
 This Python package provides command line tools for working with the catkin meta-buildsystem and catkin workspaces.
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -5,8 +5,8 @@ You can install the ``catkin_tools`` package as a binary through a package manag
 
 .. note::
 
-    This project is still in beta and has not been released yet, please install from source. 
-    In particular, interface and behaviour are still subject to incompatible changes. 
+    This project is still in beta and has not been released yet, please install from source.
+    In particular, interface and behaviour are still subject to incompatible changes.
     If you rely on a stable environment, please use ``catkin_make`` instead of this tool.
 
 Installing on Ubuntu with apt-get

--- a/docs/mechanics.rst
+++ b/docs/mechanics.rst
@@ -81,7 +81,7 @@ Hidden Marker / Config Directory
 In addition to the standard workspace structure, ``catkin_tools`` also adds a
 marker directory called ``.catkin_tools`` at the root of the workspace. This
 directory both acts as a marker for the root of the workspace and contains
-persistent configuration information. 
+persistent configuration information.
 
 This directory contains subdirectories representing different configuration
 profiles, and inside of each profile directory are YAML files which contain
@@ -194,8 +194,8 @@ subsequently targets would be built with one or more invocations of ``make``:
 In order to help automate the merged build process, Catkin was distributed
 with a command-line tool called ``catkin_make``.
 This command automated the above CMake work flow while setting some
-variables according to standard conventions. 
-These defaults would result in the execution of the following commands: 
+variables according to standard conventions.
+These defaults would result in the execution of the following commands:
 
 .. code-block:: bash
 
@@ -224,7 +224,7 @@ dependencies on some targets inside of their dependencies.
 Another disadvantage of the merged build process is that it can only work on a
 homogeneous workspace consisting only of Catkin CMake packages.
 Other types of packages like plain CMake packages and autotools packages cannot
-be integrated into a single configuration and a single build step. 
+be integrated into a single configuration and a single build step.
 
 Isolated Catkin Workflow
 ------------------------
@@ -288,14 +288,14 @@ Above, it's mentioned that the Catkin setup files export numerous environment
 variables, including ``CMAKE_PREFIX_PATH``. Since CMake 2.6.0, the
 ``CMAKE_PREFIX_PATH`` is used when searching for include files, binaries, or
 libraries using the ``FIND_PACKAGE()``, ``FIND_PATH()``, ``FIND_PROGRAM()``, or
-``FIND_LIBRARY()`` CMake commands. 
+``FIND_LIBRARY()`` CMake commands.
 
 As such, this is also the primary way that Catkin "chains" workspaces together.
 When you build a Catkin workspace for the first time, it will automatically use
 ``CMAKE_PREFIX_PATH`` to find dependencies. After that compilation, the value
 will be cached internally by each project as well as the Catkin setup files and
 they will ignore any changes to your ``CMAKE_PREFIX_PATH`` environment variable
-until they are cleaned. 
+until they are cleaned.
 
 .. note::
 
@@ -304,8 +304,8 @@ until they are cleaned.
   relationship between two such chained workspaces, ``A`` and ``B``, it is said
   that workspace ``B`` **extends** workspace ``A`` and workspace ``A`` is
   ***extended by** workspace ``B``. This concept is also sometimes referred to
-  as "overlaying" or "inheriting" a workspace. 
-  
+  as "overlaying" or "inheriting" a workspace.
+
 Similarly, when you ``source`` a Catkin workspace's setup file from a
 workspace's **devel space** or **install space**, it prepends the path
 containing that setup file to the ``CMAKE_PREFIX_PATH`` environment variable.
@@ -316,16 +316,16 @@ On one hand, this makes it easy and automatic to chain workspaces. At the same
 time, however, previous tools like ``catkin_make`` and ``catkin_make_isolated``
 had no easy mechanism for either making it obvious which workspace was being
 extended, nor did they provide features to explicitly extend a given workspace.
-This means that for users unaware of Catkin's use of ``CMAKE_PREFIX_PATH`` 
+This means that for users unaware of Catkin's use of ``CMAKE_PREFIX_PATH``
 
 Since it's not expected that 100% of users will read this section of the
 documentation, the ``catkin`` program adds both configuration consistency
 checking for the value of ``CMAKE_PREFIX_PATH`` and  makes it obvious on each
 invocation which workspace is being extended.  Furthermore, the ``catkin``
 command adds an explicit extension interface to override the value of
-``$CMAKE_PREFIX_PATH`` with the ``catkin config --extend`` command. 
+``$CMAKE_PREFIX_PATH`` with the ``catkin config --extend`` command.
 
-.. note:: 
+.. note::
 
   While workspaces can be chained together to add search paths, invoking a
   build in one workspace will not cause products in any other workspace to be

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -14,15 +14,15 @@ The following is an example workflow and sequence of commands using default
 settings:
 
 .. code-block:: bash
-    
+
     $ mkdir -p /tmp/path/to/my_catkin_ws/src      # Make a new workspace and source space
     $ cd /tmp/path/to/my_catkin_ws                # Navigate to the workspace root
     $ catkin init                                 # Initialize it with a hidden marker file
     $ cd /tmp/path/to/my_catkin_ws/src            # Navigate to the source space
     $ catkin create pkg pkg_a                     # Populate the source space with packages...
-    $ catkin create pkg pkg_b                 
-    $ catkin create pkg pkg_c --catkin-deps pkg_a                 
-    $ catkin create pkg pkg_d --catkin-deps pkg_a pkg_b                
+    $ catkin create pkg pkg_b
+    $ catkin create pkg pkg_c --catkin-deps pkg_a
+    $ catkin create pkg pkg_d --catkin-deps pkg_a pkg_b
     $ catkin build                                # Build all packages in the workspace
     $ source ../devel/setup.bash                  # Load the workspace's environment
     $ catkin clean --all                          # Clean the build products
@@ -40,7 +40,7 @@ This is done by simply creating a new workspace with an empty **source space**
 (named ``src`` by default) and calling ``catkin init`` from the workspace root:
 
 .. code-block:: bash
-    
+
     $ mkdir -p /tmp/path/to/my_catkin_ws/src
     $ cd /tmp/path/to/my_catkin_ws
     $ catkin init
@@ -110,7 +110,7 @@ For more information on Catkin packages see :doc:`workspace mechanics
 trivial packages: ``pkg_a``, ``pkg_b``, and ``another_one``:
 
 .. code-block:: bash
-    
+
     $ cd /tmp/path/to/my_catkin_ws/src
     $ catkin_create_pkg pkg_a
     Created file pkg_a/CMakeLists.txt
@@ -125,7 +125,7 @@ trivial packages: ``pkg_a``, ``pkg_b``, and ``another_one``:
     Created file another_one/package.xml
     Successfully created files in /tmp/path/to/my_catkin_ws/src/another_one. Please adjust the values in package.xml.
 
-After these operations, your workspace's local directory structure would look like 
+After these operations, your workspace's local directory structure would look like
 the followng (to two levels deep):
 
 .. code-block:: bash
@@ -182,16 +182,16 @@ and build each of them.
     Additional catkin Make Args: None
     --------------------------------------------------------------
     Workspace configuration appears valid.
-    -------------------------------------------------------------- 
-    Found '3' packages in 0.0 seconds. 
-    Starting ==> another_one                             
-    Starting ==> pkg_a                                   
-    Starting ==> pkg_b                                   
-    Finished <== pkg_b       [ 2.0 seconds ]             
-    Finished <== another_one [ 2.0 seconds ]             
-    Finished <== pkg_a       [ 3.4 seconds ]             
-    [build] Finished.                                    
-    [build] Runtime: 3.4 seconds 
+    --------------------------------------------------------------
+    Found '3' packages in 0.0 seconds.
+    Starting ==> another_one
+    Starting ==> pkg_a
+    Starting ==> pkg_b
+    Finished <== pkg_b       [ 2.0 seconds ]
+    Finished <== another_one [ 2.0 seconds ]
+    Finished <== pkg_a       [ 3.4 seconds ]
+    [build] Finished.
+    [build] Runtime: 3.4 seconds
 
 Calling ``catkin build`` will generate ``build`` and ``devel`` directories (as
 described in the config summary above) and result in a directory structure like
@@ -228,7 +228,7 @@ spaces**. In the default build configuration, only the **devel space** is
 generated. You can load the environment for your respective shell like so:
 
 .. code-block:: bash
-    
+
     $ source /tmp/path/to/my_catkin_ws/devel/setup.bash
 
 At this point you should be able to use products built by any of the packages
@@ -255,7 +255,7 @@ Cleaning Workspace Products
 
 Instead of using dangerous commands like ``rm -rf build devel`` in your
 workspace when cleaning build products, you can use the ``catkin clean --all``
-command. Just like the other verbs, ``catkin clean`` is context-aware, so it 
+command. Just like the other verbs, ``catkin clean`` is context-aware, so it
 only needs to be called from a directory under the workspace root.
 
 In order to clean the **build space** and **devel space** for the workspace,

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -27,7 +27,7 @@ Dependency Resolution
 ^^^^^^^^^^^^^^^^^^^^^
 
 A package can't find certain resources
--------------------------------------
+--------------------------------------
 
 A package doesn't find the right version of a dependency
 --------------------------------------------------------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -6,7 +6,7 @@ Configuration Summary Warnings
 
 The ``catkin`` tool is capable of detecting some issues or inconsistencies with
 the build configuration automatically. In these cases, it will often describe
-the problem as well as how to resolve it. The ``catkin`` tool will detect the 
+the problem as well as how to resolve it. The ``catkin`` tool will detect the
 following issues automatically.
 
 Missing Workspace Components

--- a/docs/verbs/catkin_build.rst
+++ b/docs/verbs/catkin_build.rst
@@ -11,7 +11,7 @@ Workspaces can also be built from arbitrary working directories if the user spec
 .. note::
 
     To set up the workspace and clone the repositories used in the following
-    examples, you can use `rosinstall_generator <http://wiki.ros.org/rosinstall_generator>`_ and `wstool <http://wiki.ros.org/wstool>`_. This 
+    examples, you can use `rosinstall_generator <http://wiki.ros.org/rosinstall_generator>`_ and `wstool <http://wiki.ros.org/wstool>`_. This
     clones all of the ROS packages necessary for building the introductory
     ROS tutorials:
 
@@ -166,7 +166,7 @@ Skipping Packages
 -----------------
 
 Suppose you built every package up to ``roscpp_tutorials``, but that package
-had a build error. 
+had a build error.
 After fixing the error, you could run the same build command again, but the
 ``build`` verb provides an option to save time in this situation.
 If re-started from the beginning, none of the products of the dependencies of
@@ -300,7 +300,7 @@ been written.
     common_msgs        gencpp             genmsg             message_generation
     ros                ros_tutorials      rospack
 
-.. note:: 
+.. note::
 
     The products of ``catkin build`` differ significantly from the behavior of
     ``catkin_make``, for example, which would have all of the build files and
@@ -333,13 +333,13 @@ Status Line
 -----------
 
 While running ``catkin build`` with default options, you would have seen the
-"live" status lines similar to the following: 
+"live" status lines similar to the following:
 
 .. code-block:: none
 
     [build - 5.9] [genmsg - 1.3] [message_runtime - 0.7] ...        [4/4 Active | 3/36 Completed]
 
-This status line stays at the bottom of the screen and displays the continuously-updated progress 
+This status line stays at the bottom of the screen and displays the continuously-updated progress
 of the entire build as well as the active build jobs which are still running. It is composed
 of the following information:
 
@@ -422,15 +422,15 @@ well as the output of each build command in a block, once it finishes:
 
     Finished <== catkin [ 3.4 seconds ]
 
-.. note:: 
-    
+.. note::
+
     The printing of these command outputs maybe be interleaved with commands
     from other package builds if more than one package is being built at the
     same time.
 
 By default ``catkin build`` will build up to ``N`` packages in parallel and
 pass ``-jN -lN`` to ``make`` where ``N`` is the number of cores in your
-computer.  
+computer.
 
 You can change the number of packages allowed to build in parallel
 by using the ``-p`` or ``--parallel-jobs`` option and you can change the jobs
@@ -464,7 +464,7 @@ when interleaved output is used ``catkin build`` prefixes each line with
     [rosclean]: -- The CXX compiler identification is Clang 5.0.0
     [rosclean]: -- Check for working C compiler: /usr/bin/cc
 
-.. note:: 
+.. note::
 
     When you use ``-p 1`` and ``-v`` at the same time, ``-i`` is implicitly added.
 

--- a/docs/verbs/catkin_config.rst
+++ b/docs/verbs/catkin_config.rst
@@ -7,10 +7,10 @@ configuration summary.
 
 By default, the ``config`` verb gets and sets options for a workspace's
 *active* profile. If no profiles have been specified for a wotkspace, this is a
-default profile named ``default``. 
+default profile named ``default``.
 
 .. note::
-  
+
   Calling ``catkin config`` on an uninitialied workspace will not automatically
   initialize it unless it is used with the ``--init`` option.
 
@@ -23,7 +23,7 @@ the root of the workspace. Doing so will not modify your workspace. The
 ``catkin`` command is context-sensitive, so it will determine which workspace
 contains the current working directory.
 
-Installing Packages 
+Installing Packages
 ^^^^^^^^^^^^^^^^^^^
 
 Without any additional arguments, packages are not "installed" using the
@@ -51,7 +51,7 @@ sometimes the extended workspace is referred to as a "parent" workspace.
 
 With ``catkin config``, you can explicitly set the workspace you want to extend,
 using the ``--extend`` argument. This is equivalent to sourcing a setup file,
-building, and then reverting to the environment before sourcing the setup file. 
+building, and then reverting to the environment before sourcing the setup file.
 
 Note that in case the desired parent workspace is different from one already
 being used, using the ``--extend`` argument also necessitates cleaning the
@@ -67,7 +67,7 @@ source a workspace:
 .. code-block:: bash
 
     $ echo $CMAKE_PREFIX_PATH
-    
+
     $ mkdir -p /tmp/path/to/my_catkin_ws/src
     $ cd /tmp/path/to/my_catkin_ws
     $ catkin init
@@ -80,7 +80,7 @@ source a workspace:
     Workspace configuration appears valid.
     --------------------------------------------------------------
 
-    $ cd /tmp/path/to/my_catkin_ws 
+    $ cd /tmp/path/to/my_catkin_ws
     $ catkin create pkg aaa
     $ catkin create pkg bbb
     $ catkin create pkg ccc
@@ -108,7 +108,7 @@ workspace. Suppose you wanted to extend a standard ROS system install like
 
 .. code-block:: bash
 
-    
+
     $ catkin config --extend /opt/ros/hydro
     --------------------------------------------------------------
     Profile:                     default

--- a/docs/verbs/catkin_init.rst
+++ b/docs/verbs/catkin_init.rst
@@ -3,7 +3,7 @@
 
 The ``init`` verb is the simplest way to "initialize" a catkin workspace so that
 it can be automatically detected automatically by other verbs which need to know
-the location of the workspace root. 
+the location of the workspace root.
 
 This verb does not store any configuration information, but simply creates the
 hidden ``.catkin_tools`` directory in the specified workspace. If you want to
@@ -12,7 +12,7 @@ initialize a workspace simultaneously with an initial config, see the
 
 Catkin workspaces can be initialized anywhere. The only constraint is that
 catkin workspaces cannot contain other catkin workspaces. If you call ``caktin
-init`` and it reports an error saying that the given directory is already 
+init`` and it reports an error saying that the given directory is already
 contained in a workspace, you can call ``catkin config`` to determine the root
 of that workspace.
 

--- a/docs/verbs/catkin_profile.rst
+++ b/docs/verbs/catkin_profile.rst
@@ -3,11 +3,11 @@
 
 Many verbs contain a ``--profile`` option, which selects which configuration
 profile to use, without which it will use the "active" profile. The ``profile``
-verb enables you to manager the available profiles as well as set the "active" 
+verb enables you to manager the available profiles as well as set the "active"
 profile when using other verbs.
 
 Even without using the ``profile`` verb, any use of the ``catkin`` command
-which changes the workspace is impliclty using a configuration profile called 
+which changes the workspace is impliclty using a configuration profile called
 "default".
 
 The ``profile`` verb has several sub-commands for profile management. These include
@@ -99,7 +99,7 @@ options:
     - default (active)
 
 Note that while the profile named ``alternate`` has been configured, it is
-still not *active*, so any calls to catkin-verbs without an explicit 
+still not *active*, so any calls to catkin-verbs without an explicit
 ``--profile alternate`` option will still use the profile named ``default``.
 
 Explicitly Creating Profiles

--- a/docs/verbs/catkin_profile.rst
+++ b/docs/verbs/catkin_profile.rst
@@ -232,7 +232,7 @@ Full Command-Line Interface
       --copy-active        Copy the settings from the active profile.
 
 ``catkin profile rename``
------------------------
+-------------------------
 
 .. code-block:: text
 
@@ -247,7 +247,7 @@ Full Command-Line Interface
       -f, --force   Overwrite an existing profile.
 
 ``catkin profile remove``
------------------------
+-------------------------
 
 .. code-block:: text
 

--- a/docs/verbs/catkin_profile.rst
+++ b/docs/verbs/catkin_profile.rst
@@ -39,6 +39,7 @@ To see these effects, you can run ``catkin config`` to write a default
 configuration to the workspace:
 
 .. code-block:: bash
+
     $ cd /tmp/path/to/my_catkin_ws
     $ catkin config
     --------------------------------------------------------------


### PR DESCRIPTION
Just some things I found while reviewing the code (yes I am still working on it... just ever so slowly).

Honestly most of these things should be caught by your editor, I would suggest upgrading your tools to have better checking of static code.
- Trailing whitespace: be4b11b
- These are just nice to have:
  - unused imports: 6ed95b8
  - unused variables: 9c8bbd9
- But this one would case run time errors!!: 14e68b9

The rest were caught by running the doc generation locally, there were a handful of sphinx warnings.

I'm play testing (for lack of a better phrase) the tools. I think they are really good, and we can probably address small behavior and feature things after merging the main pull request. My final task is to review the changes to the docs. Then we should be good to merge this guy.

Thanks again for this MAJOR contribution. I'm sure a lot the community will appreciate it!
